### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.84.1"


### PR DESCRIPTION
# Summary

Added a `rust-toolchain.toml`. I started by using rust `stable` which had issues with `cargo test`. Not sure this is the version you want, but figured it could be helpful to include this so that future repo users are on a specific version of rust